### PR TITLE
Fix room crafting tab desktop UI

### DIFF
--- a/chimera (1).html
+++ b/chimera (1).html
@@ -87,6 +87,7 @@
         .rc-locked { opacity: 0.55; filter: grayscale(0.2); }
         .rune-essence-token { display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--border-color); background: rgba(2,6,23,0.5); padding: 6px 10px; border-radius: 9999px; cursor: grab; user-select: none; }
         .rune-output-badge { display:inline-flex; align-items:center; gap:6px; border:1px solid rgba(88,166,255,0.35); background: rgba(2,6,23,0.6); padding: 6px 10px; border-radius: 9999px; }
+        @media (min-width: 768px) { .altar-zone { height: 360px; } }
         /* New gathering themes */
         .border-farming { border-color: #6b8e23; } .bg-farming { background-color: #6b8e23; }
         .border-hunter { border-color: #556b2f; } .bg-hunter { background-color: #556b2f; }
@@ -1414,7 +1415,7 @@
                 }).join('');
 
                 const altar = `
-                    <div class="block p-4 col-span-1 md:col-span-2">
+                    <div class="block p-4 col-span-1 md:col-span-1">
                         <h2 class="text-lg font-bold mb-2">Runic Altar</h2>
                         <div class="altar-zone" id="altar-dropzone">
                             <div class="altar-glow"></div>
@@ -1436,9 +1437,9 @@
                 `;
 
                 const recipeList = `
-                    <div class="block p-4">
+                    <div class="block p-4 col-span-1 md:col-span-2">
                         <h2 class="text-lg font-bold mb-2">Altars</h2>
-                        <div class="grid grid-cols-1 gap-3">${recipeCards}</div>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">${recipeCards}</div>
                     </div>
                 `;
 

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1024,7 +1024,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }).join('');
 
             const altar = `
-                <div class="block p-4 col-span-1 md:col-span-2">
+                <div class="block p-4 col-span-1 md:col-span-1">
                     <h2 class="text-lg font-bold mb-2">Runic Altar</h2>
                     <div class="altar-zone" id="altar-dropzone">
                         <div class="altar-glow"></div>
@@ -1046,13 +1046,13 @@ document.addEventListener('DOMContentLoaded', () => {
             `;
 
             const recipeList = `
-                <div class="block p-4">
+                <div class="block p-4 col-span-1 md:col-span-2">
                     <h2 class="text-lg font-bold mb-2">Altars</h2>
-                    <div class="grid grid-cols-1 gap-3">${recipeCards}</div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">${recipeCards}</div>
                 </div>
             `;
 
-            return `<div class="grid grid-cols-1 md:grid-cols-3 gap-4">${altar}${recipeList}</div>`;
+            return `<div class=\"grid grid-cols-1 md:grid-cols-3 gap-4\">${altar}${recipeList}</div>`;
         }
 
         renderBankView() {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -195,3 +195,7 @@ body {
 .rc-altar-card.rc-selected { border-color: rgba(255,255,255,0.4); box-shadow: 0 0 0 1px rgba(88,166,255,0.25) inset; }
 .rc-locked { opacity: 0.55; filter: grayscale(0.2); }
 .bg-primary { background-color: var(--bg-primary); }
+
+@media (min-width: 768px) {
+  .altar-zone { height: 360px; }
+}


### PR DESCRIPTION
Adjust Runecrafting tab layout for desktop to resolve squished UI and improve spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-888f9b15-8086-4df7-a963-a4d084d373eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-888f9b15-8086-4df7-a963-a4d084d373eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

