### PR TITLE
Fix and epicify raids tab ui

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -2722,9 +2722,27 @@ document.addEventListener('DOMContentLoaded', () => {
             const spoilsEmpty = (Math.floor(auto.buffers?.gold||0) <= 0) && itemsEntries.length === 0;
             const killProgress = Math.max(0, Math.min(1, (auto.killsFrac || 0) % 1));
             const allies = this.game.state.army.production || { dps: 0, hps: 0 };
+            const armyUnitsTotal = Object.values(this.game.state.army.units || {}).reduce((a,b)=>a+(b||0),0);
+            const emptyState = armyUnitsTotal > 0 ? '' : `
+                <div class="block p-4 rounded-md mb-4">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h2 class="text-lg font-bold">Your legion stands idle</h2>
+                            <p class="text-secondary text-sm">Recruit units in the Army tab to begin raiding.</p>
+                        </div>
+                        <button id="goto-army" class="chimera-button juicy-button px-4 py-2 rounded-md">Go to Army</button>
+                    </div>
+                </div>`;
+
+            const legionChips = Object.keys(GAME_DATA.ARMY_CLASSES).map(id => {
+                const def = GAME_DATA.ARMY_CLASSES[id];
+                const owned = this.game.state.army.units?.[id] || 0;
+                if (!owned) return '';
+                return `<div class="unit-chip"><span>${def.emoji}</span><span class="text-xs">${def.name}</span><span class="font-mono text-white">x${owned}</span></div>`;
+            }).join('');
 
             return `
-                <div class="block p-5 mb-5 medieval-glow combat-hero">
+                <div class="block p-5 mb-5 medieval-glow raids-hero">
                     <div class="flex items-center justify-between gap-3">
                         <div class="flex items-center gap-3">
                             <div class="text-2xl">🐉</div>
@@ -2739,17 +2757,18 @@ document.addEventListener('DOMContentLoaded', () => {
                         </div>
                     </div>
                 </div>
+                ${emptyState}
                 <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
                     <div class="block p-4 rounded-md space-y-3">
                         <h2 class="text-lg font-bold">Targets</h2>
                         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-1 gap-3">
                             ${(GAME_DATA.COMBAT.ENEMIES||[]).map(e => `
-                                <div class="enemy-card glass-card p-4 rounded-md flex items-center justify-between">
+                                <div class="enemy-card glass-card p-4 rounded-md flex items-center justify-between ${auto.targetId===e.id ? 'selected' : ''}">
                                     <div>
                                         <div class="font-bold">${e.name}</div>
                                         <div class="text-xs text-secondary">Lv ${e.level} • ${e.maxHp} HP</div>
                                     </div>
-                                    <button class="chimera-button juicy-button px-3 py-2 rounded-md select-raid-target" data-enemy-id="${e.id}">Target</button>
+                                    <button class="chimera-button juicy-button px-3 py-2 rounded-md select-raid-target" data-enemy-id="${e.id}">${auto.targetId===e.id ? 'Selected' : 'Target'}</button>
                                 </div>
                             `).join('')}
                         </div>
@@ -2776,13 +2795,19 @@ document.addEventListener('DOMContentLoaded', () => {
                             </div>
                         </div>
                     </div>
-                    <div class="block p-4 rounded-md space-y-3 spoils-panel">
-                        <h2 class="text-lg font-bold">War Spoils</h2>
-                        <div class="text-sm mb-1">Gold: <span id="war-spoils-gold" class="font-mono spoils-gold">${Math.floor(auto.buffers?.gold||0).toLocaleString()}</span></div>
-                        <div id="war-spoils-items" class="flex flex-wrap gap-2">${itemsHtml}</div>
-                        <div class="flex items-center gap-2">
-                            <button id="claim-war-spoils" class="chimera-button juicy-button px-3 py-2 rounded-md" ${spoilsEmpty?'disabled':''}>Claim All</button>
-                            <button id="clear-war-spoils" class="chimera-button px-3 py-2 rounded-md" ${spoilsEmpty?'disabled':''}>Clear</button>
+                    <div class="flex flex-col gap-4">
+                        <div class="block p-4 rounded-md space-y-3 spoils-panel">
+                            <h2 class="text-lg font-bold">War Spoils</h2>
+                            <div class="text-sm mb-1">Gold: <span id="war-spoils-gold" class="font-mono spoils-gold">${Math.floor(auto.buffers?.gold||0).toLocaleString()}</span></div>
+                            <div id="war-spoils-items" class="flex flex-wrap gap-2">${itemsHtml}</div>
+                            <div class="flex items-center gap-2">
+                                <button id="claim-war-spoils" class="chimera-button juicy-button px-3 py-2 rounded-md" ${spoilsEmpty?'disabled':''}>Claim All</button>
+                                <button id="clear-war-spoils" class="chimera-button px-3 py-2 rounded-md" ${spoilsEmpty?'disabled':''}>Clear</button>
+                            </div>
+                        </div>
+                        <div class="block p-4 rounded-md">
+                            <h2 class="text-lg font-bold mb-2">Legion</h2>
+                            <div class="flex flex-wrap gap-2">${legionChips || '<span class="text-secondary text-xs">No units yet.</span>'}</div>
                         </div>
                     </div>
                 </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -272,6 +272,7 @@ body {
 .combat-hero { background: radial-gradient(120% 120% at 0% 0%, rgba(255,215,0,0.12), rgba(88,166,255,0.08)), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(0,0,0,0)); border: 1px solid var(--border-color); box-shadow: 0 12px 30px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255,0.04); }
 .enemy-card { transition: transform 140ms ease, box-shadow 180ms ease; }
 .enemy-card:hover { transform: translateY(-2px); box-shadow: 0 12px 22px rgba(0,0,0,0.35); }
+.enemy-card.selected { outline: 1px solid rgba(255,215,0,0.35); box-shadow: 0 0 0 1px rgba(255,215,0,0.08) inset, 0 10px 18px rgba(0,0,0,0.35); }
 .level-badge { display:inline-block; padding:2px 8px; border-radius:9999px; font-size:11px; background: #111827; border:1px solid var(--border-color); }
 .battle-arena { position: relative; background: radial-gradient(100% 120% at 50% 20%, rgba(255,255,255,0.02), rgba(0,0,0,0)), linear-gradient(180deg, rgba(88,166,255,0.06), rgba(0,0,0,0)); border: 1px solid var(--border-color); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.03); }
 .battle-arena::after { content: ""; position: absolute; inset: -1px; pointer-events: none; background: conic-gradient(from 0deg, rgba(255,215,0,0.06), rgba(255,255,255,0.03), rgba(88,166,255,0.06)); filter: blur(10px); opacity: 0.35; }


### PR DESCRIPTION
Enhance Raids tab UI by adding an empty state, highlighting selected targets, and displaying Legion composition to address user feedback.

The Raids tab was empty when no units were recruited, so this PR introduces an empty state with a CTA to recruit an army. It also improves the user experience by visually highlighting the selected raid target and providing a summary of the user's current Legion.

---
<a href="https://cursor.com/background-agent?bcId=bc-44f581ed-8e24-46d8-aa7d-f29d3b507170">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44f581ed-8e24-46d8-aa7d-f29d3b507170">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

