### PR TITLE
Fix a typo in the `handleEnemyDefeat` function that caused an error w…

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1691,9 +1691,8 @@ document.addEventListener('DOMContentLoaded', () => {
                          const rareKey = target.sharedDropTable.replace('_common','_rare');
                          if ((Math.random() * 100) < 25 && (GAME_DATA.LOOT?.sharedTables?.[rareKey])) {
                              const rr = this.rollSharedTable(rareKey);
-                             if (rr) {
-                                 if (!auto.buffers.items) auto.buffers.items = {};
-                                 auto.buffers.items[rr.id] = (auto.buffers.items[rr.id] || 0) + rr.qty;
+                     if (rareRoll) {
+                         itemsMap[rareRoll.id] = (itemsMap[rareRoll.id] || 0) + rareRoll.qty;
                              }
                          }
                      }


### PR DESCRIPTION
…hen calculating rare loot drops from enemies with a shared drop table. The variable `rr` was used instead of `rareRoll`.

This change also corrects the reward handling for rare loot to be consistent with other drops by adding the item to the `itemsMap` object.